### PR TITLE
New infrastructure automation for the maze service

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,7 +4,7 @@ from . import maze
 app = Flask(__name__)
 
 
-@app.route("/")
+@app.route("/maze")
 def home():
     width = int(request.args.get("width", 20))
     height = int(request.args.get("height", 10))

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,29 @@
+version: 0.2
+phases: 
+  install:
+    runtime-versions:
+        docker: 18     
+    commands: 
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+  pre_build: 
+    commands: 
+    - echo Logging in to Amazon ECR.... 
+    - aws --version
+    - $(aws ecr get-login --no-include-email --region eu-west-1)
+    - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+  build:
+    commands: 
+    - echo Build started on `date` 
+    - echo Building the Docker image... 
+    - docker build -t $ECRURI:latest .
+    - docker tag $ECRURI:latest $ECRURI:$IMAGE_TAG 
+  post_build: 
+    commands: 
+    - echo Build completed on `date` 
+    - echo pushing to repo
+    - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECRURI
+    - docker push $ECRURI:latest
+    - docker push $ECRURI:$IMAGE_TAG
+    - echo Writing image definitions file... 
+    - printf '{"ImageURI":"%s"}' $ECRURI:$IMAGE_TAG 

--- a/scripts/ECRcloudformation.json
+++ b/scripts/ECRcloudformation.json
@@ -18,6 +18,16 @@
             "Default": "6502293065",
             "Type": "String",
             "Description": "phone to alert"
+        },
+        "Environment": {
+            "Default": "stage",
+            "Description": " Type of environment",
+            "Type": "String"
+        },
+        "GithubURL": {
+            "Default": "https://github.com/quentinDERORY/sample-service",
+            "Description": " URL of the github repo (must be connected with your aws account)",
+            "Type": "String"
         }
     },
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -29,17 +39,161 @@
                     "Ref": "ApplicationName"
                 },
                 "ImageTagMutability": "MUTABLE"
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "29b3799b-b05a-4b50-8f64-045467a74fbf"
+                }
             }
         },
-        "AlertEmail": {
-            "Default": "derory.quentin@gmail.com",
-            "Type": "String",
-            "Description": "Email to alert"
+        "CodeBuild": {
+            "Type": "AWS::CodeBuild::Project",
+            "Properties": {
+                "Artifacts": {
+                    "Type": "NO_ARTIFACTS"
+                },
+                "ServiceRole": {
+                    "Ref": "BuildRole"
+                },
+                "Source": {
+                    "Auth": {
+                        "Type": "OAUTH"
+                    },
+                    "Location": {
+                        "Ref": "GithubURL"
+                    },
+                    "Type": "GITHUB",
+                    "GitCloneDepth": 1,
+                    "ReportBuildStatus": true
+                },
+                "TimeoutInMinutes": 60,
+                "SourceVersion": "master",
+                "Cache": {
+                    "Type": "LOCAL",
+                    "Modes": [
+                        "LOCAL_DOCKER_LAYER_CACHE"
+                    ]
+                },
+                "LogsConfig": {
+                    "CloudWatchLogs": {
+                        "GroupName": {
+                            "Ref": "CodePipelineLogs"
+                        },
+                        "Status": "ENABLED",
+                        "StreamName": {
+                            "Fn::Sub": "${Environment}.${ApplicationName}.build"
+                        }
+                    }
+                },
+                "Environment": {
+                    "ComputeType": "BUILD_GENERAL1_SMALL",
+                    "EnvironmentVariables": [
+                        {
+                            "Name": "ECRURI",
+                            "Type": "PLAINTEXT",
+                            "Value": {
+                                "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ContainerRegistry}"
+                            }
+                        }
+                    ],
+                    "PrivilegedMode": true,
+                    "Image": "aws/codebuild/standard:4.0",
+                    "ImagePullCredentialsType": "CODEBUILD",
+                    "Type": "LINUX_CONTAINER"
+                },
+                "Name": {
+                    "Fn::Sub": "${Environment}-${ApplicationName}-build"
+                },
+                "QueuedTimeoutInMinutes": 20
+            },
+            "DependsOn": [
+                "ContainerRegistry"
+            ],
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "ef904bf1-18f7-4967-804f-0875517092a5"
+                }
+            }
         },
-        "AlertPhone": {
-            "Default": "6502293065",
-            "Type": "String",
-            "Description": "phone to alert"
+        "BuildRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "codebuild.amazonaws.com"
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "AllowLogstreaming",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents",
+                                        "logs:CreateLogGroup",
+                                        "logs:DescribeLogStreams"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:",
+                                                    "logs:",
+                                                    {
+                                                        "Ref": "AWS::Region"
+                                                    },
+                                                    ":*:*"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ecr:GetAuthorizationToken",
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:GetRepositoryPolicy",
+                                        "ecr:DescribeRepositories",
+                                        "ecr:ListImages",
+                                        "ecr:DescribeImages",
+                                        "ecr:BatchGetImage",
+                                        "ecr:GetLifecyclePolicy",
+                                        "ecr:GetLifecyclePolicyPreview",
+                                        "ecr:ListTagsForResource",
+                                        "ecr:DescribeImageScanFindings",
+                                        "ecr:InitiateLayerUpload",
+                                        "ecr:UploadLayerPart",
+                                        "ecr:CompleteLayerUpload",
+                                        "ecr:PutImage"
+                                    ],
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "5c1d6b36-53cb-4b58-b2c5-cfda4ad320c1"
+                }
+            }
         },
         "NotificationTopic": {
             "Type": "AWS::SNS::Topic",
@@ -69,6 +223,37 @@
                         "Protocol": "sms"
                     }
                 ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "08348c97-f8ae-4c7f-9156-f55bcefac48e"
+                }
+            }
+        },
+        "CodePipelineLogs": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "CodePipeline.",
+                            {
+                                "Ref": "Environment"
+                            },
+                            ".",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "RetentionInDays": 7
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "84a47305-5c48-4f69-814b-dd32eda16d2c"
+                }
             }
         }
     },
@@ -78,13 +263,77 @@
                 "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ContainerRegistry}"
             }
         },
-                "UpdateTopic": {
+        "UpdateTopic": {
             "Value": {
                 "Ref": "NotificationTopic"
             }
         }
     },
     "Metadata": {
-        "AWS::CloudFormation::Designer": {}
+        "AWS::CloudFormation::Designer": {
+            "84a47305-5c48-4f69-814b-dd32eda16d2c": {
+                "size": {
+                    "width": 150,
+                    "height": 150
+                },
+                "position": {
+                    "x": 60,
+                    "y": 90
+                },
+                "z": 1,
+                "embeds": []
+            },
+            "08348c97-f8ae-4c7f-9156-f55bcefac48e": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 270,
+                    "y": 90
+                },
+                "z": 1,
+                "embeds": []
+            },
+            "5c1d6b36-53cb-4b58-b2c5-cfda4ad320c1": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 270,
+                    "y": 210
+                },
+                "z": 1,
+                "embeds": []
+            },
+            "29b3799b-b05a-4b50-8f64-045467a74fbf": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 60,
+                    "y": 300
+                },
+                "z": 1,
+                "embeds": []
+            },
+            "ef904bf1-18f7-4967-804f-0875517092a5": {
+                "size": {
+                    "width": 60,
+                    "height": 60
+                },
+                "position": {
+                    "x": 390,
+                    "y": 90
+                },
+                "z": 1,
+                "embeds": [],
+                "dependson": [
+                    "29b3799b-b05a-4b50-8f64-045467a74fbf"
+                ]
+            }
+        }
     }
 }

--- a/scripts/ECRcloudformation.json
+++ b/scripts/ECRcloudformation.json
@@ -1,0 +1,90 @@
+{
+    "Parameters": {
+        "ApplicationName": {
+            "Default": "mazeservice",
+            "Description": "will be used for api dns name and resources names",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "64",
+            "AllowedPattern": "[a-z0-9]*",
+            "ConstraintDescription": "must contain only lowercase alphanumeric characters."
+        },
+        "AlertEmail": {
+            "Default": "derory.quentin@gmail.com",
+            "Type": "String",
+            "Description": "Email to alert"
+        },
+        "AlertPhone": {
+            "Default": "6502293065",
+            "Type": "String",
+            "Description": "phone to alert"
+        }
+    },
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "ContainerRegistry": {
+            "Type": "AWS::ECR::Repository",
+            "Properties": {
+                "RepositoryName": {
+                    "Ref": "ApplicationName"
+                },
+                "ImageTagMutability": "MUTABLE"
+            }
+        },
+        "AlertEmail": {
+            "Default": "derory.quentin@gmail.com",
+            "Type": "String",
+            "Description": "Email to alert"
+        },
+        "AlertPhone": {
+            "Default": "6502293065",
+            "Type": "String",
+            "Description": "phone to alert"
+        },
+        "NotificationTopic": {
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "TopicName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "Update-Notification-",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "Subscription": [
+                    {
+                        "Endpoint": {
+                            "Ref": "AlertEmail"
+                        },
+                        "Protocol": "EMAIL"
+                    },
+                    {
+                        "Endpoint": {
+                            "Ref": "AlertPhone"
+                        },
+                        "Protocol": "sms"
+                    }
+                ]
+            }
+        }
+    },
+    "Outputs": {
+        "ECRURI": {
+            "Value": {
+                "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ContainerRegistry}"
+            }
+        },
+                "UpdateTopic": {
+            "Value": {
+                "Ref": "NotificationTopic"
+            }
+        }
+    },
+    "Metadata": {
+        "AWS::CloudFormation::Designer": {}
+    }
+}

--- a/scripts/InfrastructureCloudformation.json
+++ b/scripts/InfrastructureCloudformation.json
@@ -1,0 +1,989 @@
+{
+    "Parameters": {
+        "ApplicationName": {
+            "Default": "mazeservice",
+            "Description": "will be used for api dns name and resources names",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "64",
+            "AllowedPattern": "[a-z0-9]*",
+            "ConstraintDescription": "must contain only lowercase alphanumeric characters."
+        },
+        "ECRURI": {
+            "Default": "690347597307.dkr.ecr.us-west-2.amazonaws.com/mazeservice",
+            "Description": "Docker container registry uri",
+            "Type": "String"
+        },
+        "Environment": {
+            "Default": "stage",
+            "Description": " Type of environment",
+            "Type": "String"
+        },
+        "DockerTag": {
+            "Default": "latest",
+            "Description": "Docker image tag",
+            "Type": "String"
+        },
+        "VpcId": {
+            "Default": "vpc-7c527704",
+            "Type": "AWS::EC2::VPC::Id",
+            "Description": "VpcId of your existing Virtual Private Cloud (VPC)",
+            "ConstraintDescription": "must be the VPC Id of an existing Virtual Private Cloud."
+        },
+        "CPUPolicyTargetValue": {
+            "Default": "70",
+            "Type": "String",
+            "Description": "The Average CPU Utilization threshold to scale up the server"
+        },
+        "Subnets": {
+            "Default": "subnet-3908d873,subnet-8abf3ed7,subnet-2af84e52",
+            "Type": "List<AWS::EC2::Subnet::Id>",
+            "Description": "The list of SubnetIds in your Virtual Private Cloud (VPC)",
+            "ConstraintDescription": "must be a list of at least two existing subnets associated with at least two different availability zones. They should be residing in the selected Virtual Private Cloud."
+        },
+        "AlertEmail": {
+            "Default": "derory.quentin@gmail.com",
+            "Type": "String",
+            "Description": "Email to alert"
+        },
+        "AlertPhone": {
+            "Default": "6502293065",
+            "Type": "String",
+            "Description": "phone to alert"
+        },
+        "KeyName": {
+            "Default": "maze-test",
+            "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances",
+            "Type": "AWS::EC2::KeyPair::KeyName",
+            "ConstraintDescription": "must be the name of an existing EC2 KeyPair."
+        },
+        "WebServerCapacity": {
+            "Default": "1",
+            "Description": "The initial number of WebServer instances",
+            "Type": "Number",
+            "MinValue": "1",
+            "MaxValue": "5",
+            "ConstraintDescription": "must be between 1 and 5 EC2 instances."
+        },
+        "InstanceType": {
+            "Description": "WebServer EC2 instance type",
+            "Type": "String",
+            "Default": "t1.micro",
+            "ConstraintDescription": "must be a valid EC2 instance type."
+        }, "ImageId": {
+            "Description": "WebServer EC2 instance ami",
+            "Type": "String",
+            "Default": "ami-0e8c04af2729ff1bb",
+            "ConstraintDescription": "must be a valid Image id."
+        }
+        
+    },
+    "Resources": {
+        "ApplicationLoadBalancer": {
+            "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+            "Properties": {
+                "SecurityGroups": [
+                    {
+                        "Ref": "LoadBalancerSG"
+                    }
+                ],
+                "Subnets": {
+                    "Ref": "Subnets"
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "4be7d876-5d6e-4b52-936a-a7e323043a3b"
+                }
+            }
+        },
+        "HttpListener": {
+            "Type": "AWS::ElasticLoadBalancingV2::Listener",
+            "Properties": {
+                "DefaultActions": [
+                    {
+                        "Type": "fixed-response",
+                        "FixedResponseConfig": {
+                            "StatusCode": "503"
+                        }
+                    }
+                ],
+                "LoadBalancerArn": {
+                    "Ref": "ApplicationLoadBalancer"
+                },
+                "Port": "80",
+                "Protocol": "HTTP"
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "40a5b9c5-4a8d-4ae2-a5a6-3afb540594c4"
+                }
+            }
+        },
+        "ALBTargetGroup": {
+            "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+            "Properties": {
+                "HealthCheckIntervalSeconds": 10,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "HealthCheckPath": "/health",
+                "Port": 5000,
+                "Protocol": "HTTP",
+                "UnhealthyThresholdCount": 5,
+                "VpcId": {
+                    "Ref": "VpcId"
+                },
+                "TargetGroupAttributes": [
+                    {
+                        "Key": "stickiness.enabled",
+                        "Value": "true"
+                    },
+                    {
+                        "Key": "stickiness.type",
+                        "Value": "lb_cookie"
+                    },
+                    {
+                        "Key": "stickiness.lb_cookie.duration_seconds",
+                        "Value": "30"
+                    }
+                ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "3ff65f24-dc68-4961-89d4-4e5444c8ee4e"
+                }
+            }
+        },
+        "WebServerGroup": {
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Properties": {
+                "VPCZoneIdentifier": {
+                    "Ref": "Subnets"
+                },
+                "HealthCheckGracePeriod": "60",
+                "HealthCheckType": "ELB",
+                "LaunchConfigurationName": {
+                    "Ref": "LaunchConfig"
+                },
+                "MinSize": "1",
+                "MaxSize": "5",
+                "DesiredCapacity": {
+                    "Ref": "WebServerCapacity"
+                },
+                "TargetGroupARNs": [
+                    {
+                        "Ref": "ALBTargetGroup"
+                    }
+                ]
+            },
+            "CreationPolicy": {
+                "ResourceSignal": {
+                    "Timeout": "PT30M"
+                }
+            },
+            "UpdatePolicy": {
+                "AutoScalingRollingUpdate": {
+                    "MinInstancesInService": "1",
+                    "MaxBatchSize": "1",
+                    "PauseTime": "PT30M",
+                    "WaitOnResourceSignals": "true"
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "722eba1f-1fc5-43f4-a756-f2c597b05651"
+                }
+            }
+        },
+        "LaunchConfig": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "configSets": {
+                        "full_install": [
+                            "install_docker",
+                            "install_logs"
+                        ]
+                    },
+                    "install_docker": {
+                        "files": {
+                            "/etc/cfn/cfn-hup.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[main]\n",
+                                            "stack=",
+                                            {
+                                                "Ref": "AWS::StackId"
+                                            },
+                                            "\n",
+                                            "region=",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000400",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[cfn-auto-reloader-hook]\n",
+                                            "triggers=post.update\n",
+                                            "path=Resources.LaunchConfig.Metadata.AWS::CloudFormation::Init\n",
+                                            "action=/opt/aws/bin/cfn-init -v ",
+                                            "         --stack ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            "         --resource LaunchConfig ",
+                                            "         --configsets full_install ",
+                                            "         --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n",
+                                            "runas=root\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000400",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/tmp/docker.env": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "TYPE_ENV=",
+                                            {
+                                                "Ref": "Environment"
+                                            },
+                                            "\n",
+                                            "AWS=true\n",
+                                            "AWS_REGION=",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n",
+                                            "API_DNS=",
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        {
+                                                            "Ref": "ApplicationName"
+                                                        },
+                                                        ".api.",
+                                                        "emodsafety.com"
+                                                    ]
+                                                ]
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000400",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/tmp/install_docker": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "#!/bin/bash -e\n",
+                                            "yum update -y\n",
+                                            "amazon-linux-extras install docker\n",
+                                            "yum install -y awslogs\n",
+                                            "cd /home/ec2-user\n",
+                                            "usermod -a -G docker ec2-user\n",
+                                            "# Remove previous version of aws cli and install v2 \n",
+                                            "which aws |xargs sudo rm | true \n",
+                                            "sudo rm -rf /usr/local/aws-cli\n",
+                                            "curl \"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip\" -o \"awscliv2.zip\" \n",
+                                            "unzip -o -qq awscliv2.zip\n",
+                                            "sudo ./aws/install\n",
+                                            "service docker start\n",
+                                            "export PATH=$PATH:/usr/local/bin\n",
+                                            "# Docker login to private registry \n",
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        "/usr/local/bin/aws ecr get-login-password --region us-west-2 | ",
+                                                        "docker login --username AWS --password-stdin ",
+                                                        {
+                                                            "Ref": "ECRURI"
+                                                        },
+                                                        "\n"
+                                                    ]
+                                                ]
+                                            },
+                                            "mkdir .docker | true\n",
+                                            "cp ~/.docker/config.json ./.docker/config.json\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000500",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/home/ec2-user/start-application": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "#!/bin/bash -e\n",
+                                            "source /etc/environment\n",
+                                            "export HOME=/home/ec2-user\n",
+                                            "cd /home/ec2-user\n",
+                                            "# Startup the application\n",
+                                            {
+                                                "Fn::Join": [
+                                                    "",
+                                                    [
+                                                        "docker run -d -p 5000:5000 --restart unless-stopped ",
+                                                        "--log-driver=awslogs --log-opt awslogs-region=",
+                                                        {
+                                                            "Ref": "AWS::Region"
+                                                        },
+                                                        " --log-opt awslogs-group=",
+                                                        "Docker.",
+                                                        {
+                                                            "Ref": "Environment"
+                                                        },
+                                                        ".",
+                                                        {
+                                                            "Ref": "ApplicationName"
+                                                        },
+                                                        " --log-opt tag=simpleService.{{.ID}}  --log-opt awslogs-datetime-format='\\[%b %d, %Y %H:%M:%S\\]'",
+                                                        " --env-file /tmp/docker.env --name simpleService ",
+                                                        {
+                                                            "Ref": "ECRURI"
+                                                        },
+                                                        ":$DOCKER_TAG \n"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                },
+                                "mode": "000500",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        },
+                        "commands": {
+                            "01_install_application": {
+                                "command": "/tmp/install_docker > /var/log/install_docker.log"
+                            },
+                            "02_configure_reboot": {
+                                "command": "echo /home/ec2-user/start-application >> /etc/rc.local"
+                            },
+                            "03_start_application": {
+                                "command": "/home/ec2-user/start-application"
+                            },
+                            "04_cleanup": {
+                                "command": "rm /tmp/install_docker"
+                            }
+                        }
+                    },
+                    "install_logs": {
+                        "packages": {
+                            "yum": {
+                                "awslogs": []
+                            }
+                        },
+                        "files": {
+                            "/etc/awslogs/awslogs.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[general]\n",
+                                            "state_file= /var/awslogs/state/agent-state\n",
+                                            "[/var/log/cloud-init.log]\n",
+                                            "file = /var/log/cloud-init.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cloud-init.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cloud-init-output.log]\n",
+                                            "file = /var/log/cloud-init-output.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cloud-init-output.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-init.log]\n",
+                                            "file = /var/log/cfn-init.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-init.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-hup.log]\n",
+                                            "file = /var/log/cfn-hup.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-hup.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-wire.log]\n",
+                                            "file = /var/log/cfn-wire.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-wire.log\n",
+                                            "datetime_format = \n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000444",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/awslogs/awscli.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[plugins]\n",
+                                            "cwlogs = cwlogs\n",
+                                            "[default]\n",
+                                            "region = ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000444",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        },
+                        "commands": {
+                            "01_reinstall_awscli_v1": {
+                                "command": "yum -qy reinstall awscli"
+                            },
+                            "02_create_state_directory": {
+                                "command": "mkdir -p /var/awslogs/state"
+                            },
+                            "03_start_awslogsd": {
+                                "command": "systemctl start awslogsd"
+                            },
+                            "04_enable_awslogd": {
+                                "command": "systemctl enable awslogsd.service"
+                            }
+                        }
+                    },
+                    "AWS::CloudFormation::Designer": {
+                        "id": "387fcf3c-6956-4db2-870e-ec6fc1f6e21f"
+                    }
+                },
+                "AWS::CloudFormation::Designer": {
+                    "id": "d41742d8-2073-45a3-830a-7ef1ab41a8b8"
+                }
+            },
+            "Properties": {
+                "IamInstanceProfile": {
+                    "Fn::GetAtt": [
+                        "InstanceProfileWebServer",
+                        "Arn"
+                    ]
+                },
+                "ImageId":{
+                    "Ref": "ImageId"
+                    },
+                "InstanceType": {
+                    "Ref": "InstanceType"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "WebServerSecurityGroup"
+                    }
+                ],
+                "KeyName": {
+                    "Ref": "KeyName"
+                },
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash -xe\n",
+                                "echo 'DOCKER_TAG=",
+                                {
+                                    "Ref": "DockerTag"
+                                },
+                                "' >> /etc/environment\n",
+                                "yum update -y aws-cfn-bootstrap\n",
+                                "/opt/aws/bin/cfn-init -v ",
+                                "         --stack ",
+                                {
+                                    "Ref": "AWS::StackId"
+                                },
+                                "         --resource LaunchConfig ",
+                                "         --configsets full_install ",
+                                "         --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n",
+                                "# Start up the cfn-hup daemon to listen for changes to the EC2 instance metadata\n",
+                                "/opt/aws/bin/cfn-hup || error_exit 'Failed to start cfn-hup'\n",
+                                "",
+                                "/opt/aws/bin/cfn-signal -e $? ",
+                                "         --stack ",
+                                {
+                                    "Ref": "AWS::StackId"
+                                },
+                                "         --resource WebServerGroup ",
+                                "         --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n"
+                            ]
+                        ]
+                    }
+                }
+            }
+        },
+        "WebServerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Enable HTTP access locked down to the load balancer",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "5000",
+                        "ToPort": "5000",
+                        "SourceSecurityGroupId": {
+                            "Fn::Select": [
+                                0,
+                                {
+                                    "Fn::GetAtt": [
+                                        "ApplicationLoadBalancer",
+                                        "SecurityGroups"
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VpcId"
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "0acb8861-1a5e-4010-bdab-95d1cdf6585c"
+                }
+            }
+        },
+        "WebServerLogGroup": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "Docker.",
+                            {
+                                "Ref": "Environment"
+                            },
+                            ".",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "RetentionInDays": 7
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "b74241dc-6120-4065-872d-3b112162361b"
+                }
+            }
+        },
+        "InstanceRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Policies": [
+                    {
+                        "PolicyName": "AllowLogstreaming",
+                        "PolicyDocument": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents",
+                                        "logs:CreateLogGroup",
+                                        "logs:DescribeLogStreams"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:aws:",
+                                                    "logs:",
+                                                    {
+                                                        "Ref": "AWS::Region"
+                                                    },
+                                                    ":*:*"
+                                                ]
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": "s3:*",
+                                    "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ecr:GetAuthorizationToken",
+                                        "ecr:BatchCheckLayerAvailability",
+                                        "ecr:GetDownloadUrlForLayer",
+                                        "ecr:GetRepositoryPolicy",
+                                        "ecr:DescribeRepositories",
+                                        "ecr:ListImages",
+                                        "ecr:DescribeImages",
+                                        "ecr:BatchGetImage",
+                                        "ecr:GetLifecyclePolicy",
+                                        "ecr:GetLifecyclePolicyPreview",
+                                        "ecr:ListTagsForResource",
+                                        "ecr:DescribeImageScanFindings",
+                                        "ecr:InitiateLayerUpload",
+                                        "ecr:UploadLayerPart",
+                                        "ecr:CompleteLayerUpload",
+                                        "ecr:PutImage"
+                                    ],
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "fd4385c9-b533-4e68-98a5-9b528fbf59f1"
+                }
+            }
+        },
+        "InstanceProfileWebServer": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "InstanceRole"
+                    }
+                ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "acee11b3-c0d6-4930-bfd2-9a6bb6dcbe1c"
+                }
+            }
+        },
+        "LoadBalancerSG": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Enable HTTP and https access on the load balancer",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "80",
+                        "ToPort": "80",
+                        "CidrIp": "0.0.0.0/0"
+                    }
+                ],
+                "VpcId": {
+                    "Ref": "VpcId"
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "e6f8d4a6-72dc-4256-9092-8fb9f26ced94"
+                }
+            }
+        },
+        "HttpListenerRule": {
+            "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+            "Properties": {
+                "ListenerArn": {
+                    "Ref": "HttpListener"
+                },
+                "Actions": [
+                    {
+                        "Type": "forward",
+                        "TargetGroupArn": {
+                            "Ref": "ALBTargetGroup"
+                        }
+                    }
+                ],
+                "Conditions": [
+                    {
+                        "Field": "path-pattern",
+                        "PathPatternConfig": {
+                            "Values": [
+                                "/maze",
+                                "/healthcheck"
+                            ]
+                        }
+                    }
+                ],
+                "Priority": 1
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "11f0db1e-7325-4719-8c87-2920a03c5170"
+                }
+            }
+        },
+        "ASGPolicy": {
+            "Type": "AWS::AutoScaling::ScalingPolicy",
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "WebServerGroup"
+                },
+                "PolicyType": "TargetTrackingScaling",
+                "TargetTrackingConfiguration": {
+                    "PredefinedMetricSpecification": {
+                        "PredefinedMetricType": "ASGAverageCPUUtilization"
+                    },
+                    "TargetValue": {
+                        "Ref": "CPUPolicyTargetValue"
+                    }
+                }
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "9f324547-9abd-4d14-9bf6-76cd2d3807d1"
+                }
+            }
+        },
+        "LoadBalancerAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "TargetResponseTime.",
+                            {
+                                "Ref": "Environment"
+                            },
+                            ".",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "ActionsEnabled": true,
+                "AlarmActions": [
+                    {
+                        "Ref": "AlertTopic"
+                    }
+                ],
+                "Namespace": "AWS/ApplicationELB",
+                "Statistic": "Average",
+                "MetricName": "TargetResponseTime",
+                "Threshold": 60,
+                "Period": 60,
+                "EvaluationPeriods": 1,
+                "ComparisonOperator": "GreaterThanThreshold",
+                "Dimensions": [
+                    {
+                        "Name": "LoadBalancer",
+                        "Value": {
+                            "Ref": "ApplicationLoadBalancer"
+                        }
+                    }
+                ],
+                "TreatMissingData": "ignore"
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "5a4e8767-bf5f-4a3d-b3e5-98b638719121"
+                }
+            }
+        },
+        "TargetGroupAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "HealthCheck.",
+                            {
+                                "Ref": "Environment"
+                            },
+                            ".",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "ActionsEnabled": true,
+                "AlarmActions": [
+                    {
+                        "Ref": "AlertTopic"
+                    }
+                ],
+                "Namespace": "AWS/ApplicationELB",
+                "Statistic": "Average",
+                "MetricName": "HealthyHostCount",
+                "Threshold": 1,
+                "EvaluationPeriods": 1,
+                "Period": 60,
+                "ComparisonOperator": "LessThanThreshold",
+                "Dimensions": [
+                    {
+                        "Name": "LoadBalancer",
+                        "Value": {
+                            "Ref": "ALBTargetGroup"
+                        }
+                    }
+                ],
+                "TreatMissingData": "ignore"
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "11a0a85c-d2f1-4cd9-861a-a19d9e083e6c"
+                }
+            }
+        },
+        "AlertTopic": {
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "TopicName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "Alert-",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "Subscription": [
+                    {
+                        "Endpoint": {
+                            "Ref": "AlertEmail"
+                        },
+                        "Protocol": "EMAIL"
+                    },
+                    {
+                        "Endpoint": {
+                            "Ref": "AlertPhone"
+                        },
+                        "Protocol": "sms"
+                    }
+                ]
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "bfc20f2c-42b4-429c-b841-2f8285f86c2e"
+                }
+            }
+        },
+        "CloudFormationLogs": {
+            "Type": "AWS::Logs::LogGroup",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "CloudFormation.",
+                            {
+                                "Ref": "Environment"
+                            },
+                            ".",
+                            {
+                                "Ref": "ApplicationName"
+                            }
+                        ]
+                    ]
+                },
+                "RetentionInDays": 7
+            },
+            "Metadata": {
+                "AWS::CloudFormation::Designer": {
+                    "id": "243d61af-e530-4543-94d7-cfee0b3e6058"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "Service": {
+            "Value": {
+                "Fn::Join": [
+                    "",
+                    [
+                        "http://",
+                        {
+                            "Fn::GetAtt": [
+                                "ApplicationLoadBalancer",
+                                "DNSName"
+                            ]
+                        },
+                        "/maze"
+                    ]
+                ]
+            },
+            "Description": "URL for the service"
+        }
+    }
+}

--- a/scripts/InfrastructureCloudformation.json
+++ b/scripts/InfrastructureCloudformation.json
@@ -126,7 +126,7 @@
                 "HealthCheckIntervalSeconds": 10,
                 "HealthCheckTimeoutSeconds": 5,
                 "HealthyThresholdCount": 2,
-                "HealthCheckPath": "/health",
+                "HealthCheckPath": "/healthcheck",
                 "Port": 5000,
                 "Protocol": "HTTP",
                 "UnhealthyThresholdCount": 5,
@@ -160,7 +160,7 @@
                 "VPCZoneIdentifier": {
                     "Ref": "Subnets"
                 },
-                "HealthCheckGracePeriod": "60",
+                "HealthCheckGracePeriod": "400",
                 "HealthCheckType": "ELB",
                 "LaunchConfigurationName": {
                     "Ref": "LaunchConfig"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,68 @@
+# README
+## Pre-Requirements
+
+### AWS CLI
+
+Setup and install the AWS CLI v2 on your local machine:
+
+ [AWS guide](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+
+
+Setup your connection in the AWS config file with your user credentials and desired region
+
+[AWS guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
+
+(Deployment was tested in us-west-2, you will need to change the AMI if switching the AWS region)
+
+### Connecting your AWS Account to your GitHub Repo
+
+Go there and connect your GitHub to your AWS account to allow codebuild to build the container.
+Select GitHub in the source, click connect to your GitHub account and follow the prompt.
+
+[codebuild wizard](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/project/new?region=us-west-2)
+
+( No need to finalize the code build wizard)
+
+## Setup the Infrastructure for the Maze Service
+
+The Automation first creates an ECR to store all the versions of the docker images.
+Then it creates the codebuild service for the container creation, tagging and publishing.
+(The codebuild will build based off a branch in the GitHub repo)
+
+The second cloudformation template creates the infrastructure needed to deploy a service behind a load balancer with an auto scaling group.
+
+It also creates three logs groups:
+- <b>Cloudformation Log,</b> group with the instance setup logs
+- <b>Docker Log</b> group with the application logs
+- The<b> Codebuild log </b> with the docker build logs
+
+
+### List of Options
+1. -v: VPC id
+2. -s: Subnets
+3. -e: email to alert
+4. -p: phone number to alert
+4. -g: github url to build the container on
+6. -b: branch to build off
+
+Go in the scripts folder to execute it:
+
+ (Here is an example)
+
+<pre><code>sh setupInfrastructure.sh -v vpc-a3f6fac5 -s subnet-09515a52\\,subnet-77394d3f\\,subnet-77267211 -e derory.quentin@gmail.com -p 6502293066 -g 'https://github.com/quentinDERORY/sample-service' -b Quentin-NewInfraForMaze
+</code></pre>
+
+## Execute a Rolling Update with a New Version
+
+It will launch the build of the container from the supplied branch and push that new version to AWS.
+The update will perform a rolling update on the autoscaling group and alert the user when finished
+### List of Options
+1. First option: Tag of the docker container
+2. Second option: Branch to trigger the build off
+
+Go in the scripts folder to execute it:
+
+ (Here is an example)
+
+<pre><code>sh setupInfrastructure.sh 3.0 Quentin-NewInfraForMaze
+</code></pre>

--- a/scripts/UpdateStack.sh
+++ b/scripts/UpdateStack.sh
@@ -1,0 +1,15 @@
+
+
+export NEWDOCKERTAG=$1
+
+export ECRURI=$(aws cloudformation describe-stacks --stack-name ecrMaze --query "Stacks[0].Outputs[0].OutputValue" --output text)
+
+cd ..
+
+echo AWSREGION=$(aws configure get region)
+
+docker build  -t $ECRURI:$DOCKERTAG .
+aws ecr get-login-password --region $AWSREGION | docker login --username AWS --password-stdin $ECRURI
+docker push $ECRURI:$DOCKERTAG 
+
+aws cloudformation update-stack --stack-name ecrMazeIT --use-previous-template --parameters ParameterKey=DockerTag,ParameterValue=$NEWDOCKERTAG ParameterKey=AlertEmail,UsePreviousValue=true ParameterKey=AlertPhone,UsePreviousValue=true ParameterKey=ECRURI,UsePreviousValue=true ParameterKey=VpcId,UsePreviousValue=true ParameterKey=Subnets,UsePreviousValue=true --capabilities CAPABILITY_NAMED_IAM

--- a/scripts/setupInfrastructure.sh
+++ b/scripts/setupInfrastructure.sh
@@ -1,0 +1,32 @@
+while getopts v:s:e:p flag
+do
+    case "${flag}" in
+        v) VPCID=${OPTARG};;
+        s) subnets=${OPTARG};;
+        e) email=${OPTARG};;
+        p) phone_number=${OPTARG};;
+    esac
+done
+
+
+aws cloudformation create-stack --stack-name ecrMaze --template-body file://ECRcloudformation.json --parameters ParameterKey=ApplicationName,ParameterValue=mazeservice 
+
+export ECRURI=$(aws cloudformation describe-stacks --stack-name ecrMaze --query "Stacks[0].Outputs[0].OutputValue" --output text)
+export TOPICARN=$(aws cloudformation describe-stacks --stack-name ecrMaze --query "Stacks[0].Outputs[1].OutputValue" --output text)
+
+cd ..
+
+echo AWSREGION=$(aws configure get region)
+
+docker build  -t $ECRURI:latest .
+aws ecr get-login-password --region $AWSREGION | docker login --username AWS --password-stdin $ECRURI
+docker push $ECRURI:latest 
+
+# create the privat key
+aws ec2 create-key-pair --key-name maze-test --query KeyMaterial --output text >> MazePrivateKey.pem
+
+# Create the stack
+cd script
+aws cloudformation create-stack --stack-name ecrMazeIT --notification-arns $TOPICARN --template-body file://InfrastructureCloudformation.json --parameters ParameterKey=ECRURI,ParameterValue=$ECRURI  ParameterKey=AlertEmail,ParameterValue=$email ParameterKey=AlertPhone,ParameterValue=$phone_number ParameterKey=ApplicationName,ParameterValue=mazeservice ParameterKey=VpcId,ParameterValue=$VPCID ParameterKey=Subnets,ParameterValue=$SUBNETS --capabilities CAPABILITY_NAMED_IAM --tags Key=environment,Value=maze
+
+aws cloudformation describe-stacks --stack-name ecrMazeIT --query "Stacks[0].Outputs[0].OutputValue" --output text

--- a/scripts/setupInfrastructure.sh
+++ b/scripts/setupInfrastructure.sh
@@ -1,32 +1,41 @@
-while getopts v:s:e:p flag
+set -e
+set -o pipefail
+
+
+while getopts v:s:e:p:g:b: flag
 do
     case "${flag}" in
         v) VPCID=${OPTARG};;
-        s) subnets=${OPTARG};;
+        s) SUBNETS=${OPTARG};;
         e) email=${OPTARG};;
         p) phone_number=${OPTARG};;
+        g) github=${OPTARG};;
+        b) BRANCH=${OPTARG};;
     esac
 done
 
 
-aws cloudformation create-stack --stack-name ecrMaze --template-body file://ECRcloudformation.json --parameters ParameterKey=ApplicationName,ParameterValue=mazeservice 
+aws cloudformation create-stack --stack-name mazeECR --template-body file://ECRcloudformation.json --parameters ParameterKey=ApplicationName,ParameterValue=mazeservice ParameterKey=AlertEmail,ParameterValue=$email ParameterKey=AlertPhone,ParameterValue=$phone_number ParameterKey=GithubURL,ParameterValue=$github --capabilities CAPABILITY_NAMED_IAM
 
-export ECRURI=$(aws cloudformation describe-stacks --stack-name ecrMaze --query "Stacks[0].Outputs[0].OutputValue" --output text)
-export TOPICARN=$(aws cloudformation describe-stacks --stack-name ecrMaze --query "Stacks[0].Outputs[1].OutputValue" --output text)
+aws cloudformation wait stack-create-complete --stack-name mazeECR
 
-cd ..
+export ECRURI=$(aws cloudformation describe-stacks --stack-name mazeECR --query "Stacks[0].Outputs[?OutputKey=='ECRURI'].OutputValue" --output text)
+export TOPICARN=$(aws cloudformation describe-stacks --stack-name mazeECR --query "Stacks[0].Outputs[?OutputKey=='UpdateTopic'].OutputValue" --output text)
 
-echo AWSREGION=$(aws configure get region)
 
-docker build  -t $ECRURI:latest .
-aws ecr get-login-password --region $AWSREGION | docker login --username AWS --password-stdin $ECRURI
-docker push $ECRURI:latest 
+export BUILDID=$(aws codebuild start-build --project-name stage-mazeservice-build --source-version $BRANCH --environment-variables-override name=IMAGE_TAG,value=latest,type=PLAINTEXT --query "build.id" --output text)
+
+export BUILDSTATUS=$(aws codebuild batch-get-builds --ids $BUILDID --query "builds[0].buildStatus" --output text)
+
+while [ $BUILDSTATUS != "SUCCEEDED" ]; do sleep 20; BUILDSTATUS=$(aws codebuild batch-get-builds --ids $BUILDID --query "builds[0].buildStatus" --output text); echo $BUILDSTATUS; done
+
 
 # create the privat key
 aws ec2 create-key-pair --key-name maze-test --query KeyMaterial --output text >> MazePrivateKey.pem
 
 # Create the stack
-cd script
-aws cloudformation create-stack --stack-name ecrMazeIT --notification-arns $TOPICARN --template-body file://InfrastructureCloudformation.json --parameters ParameterKey=ECRURI,ParameterValue=$ECRURI  ParameterKey=AlertEmail,ParameterValue=$email ParameterKey=AlertPhone,ParameterValue=$phone_number ParameterKey=ApplicationName,ParameterValue=mazeservice ParameterKey=VpcId,ParameterValue=$VPCID ParameterKey=Subnets,ParameterValue=$SUBNETS --capabilities CAPABILITY_NAMED_IAM --tags Key=environment,Value=maze
+aws cloudformation create-stack --stack-name mazeIT --notification-arns $TOPICARN --template-body file://InfrastructureCloudformation.json --parameters ParameterKey=ECRURI,ParameterValue=$ECRURI  ParameterKey=AlertEmail,ParameterValue=$email ParameterKey=AlertPhone,ParameterValue=$phone_number ParameterKey=ApplicationName,ParameterValue=mazeservice ParameterKey=VpcId,ParameterValue=$VPCID ParameterKey=Subnets,ParameterValue=$SUBNETS --capabilities CAPABILITY_NAMED_IAM --tags Key=environment,Value=maze
 
-aws cloudformation describe-stacks --stack-name ecrMazeIT --query "Stacks[0].Outputs[0].OutputValue" --output text
+aws cloudformation wait stack-create-complete --stack-name mazeIT
+
+aws cloudformation describe-stacks --stack-name mazeIT --query "Stacks[0].Outputs[0].OutputValue" --output text


### PR DESCRIPTION

Added the automation with cloudformation for:

1. the setup of the maze service in AWS:

- maze service running in elastic load balancer with routes filters and an auto scaling group
-  the service is linked to alerts and logs in CloudWatch
-  the service is built with code build and stored in ECR (created by the setup script)

2. the rolling update of the maze service

More information in scripts/Readme.MD
